### PR TITLE
refactor: remove finalized block query condition

### DIFF
--- a/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
@@ -360,8 +360,9 @@ impl EthTxAggregator {
             .await
         {
             if if let AggregatedOperation::Execute(ref op) = agg_op {
-                tracing::info!("Query batches syncing status: {:?}", op.l1_batch_range());
-                self.is_batches_synced(op).await?
+                let is_synced = self.is_batches_synced(op).await?;
+                tracing::info!("Queried Batches[op.l1_batch_range()] syncing status: {:?}", is_synced);
+                is_synced
             } else {
                 true
             } {
@@ -383,9 +384,7 @@ impl EthTxAggregator {
         let is_batches_synced = &*self.functions.is_batches_synced.name;
 
         let params = op.get_eth_tx_args().pop().unwrap();
-        let block_number = self.finalized_l1_block_numbers().await?;
         let args = CallFunctionArgs::new(is_batches_synced, params)
-            .with_block(BlockId::from(U64::from(block_number.0)))
             .for_contract(
                 self.main_zksync_contract_address,
                 self.functions.zksync_contract.clone(),


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Because executeBatch call execution, will affect the is_synced_batch query result, so, we need to ensure that each executeBatch execution tx confirmation before doing is_synced_batch query, so also can not use the previous block state.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
